### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/dotool/git.go
+++ b/dotool/git.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
 )
 
 // gitCommitAll stages all tracked changes and commits, no-op if the tree is clean.
-func gitCommitAll(msg string) error {
-	clean, err := gitTreeClean()
+func gitCommitAll(ctx context.Context, msg string) error {
+	clean, err := gitTreeClean(ctx)
 	if err != nil {
 		return err
 	}
@@ -16,20 +17,23 @@ func gitCommitAll(msg string) error {
 		log.Printf("git: nothing to commit for %q\n", msg)
 		return nil
 	}
-	return runGit("commit", "-a", "-m", msg)
+	return runGit(ctx, "commit", "-a", "-m", msg)
 }
 
 // gitTreeClean reports whether the working tree has no staged or unstaged changes.
-func gitTreeClean() (bool, error) {
-	out, err := exec.Command("git", "status", "--porcelain").Output()
+func gitTreeClean(ctx context.Context) (bool, error) {
+	out, err := exec.CommandContext(ctx, "git", "status", "--porcelain").Output()
 	if err != nil {
 		return false, fmt.Errorf("git status: %w", err)
 	}
 	return len(out) == 0, nil
 }
 
-func runGit(args ...string) error {
-	out, err := exec.Command("git", args...).CombinedOutput()
+// runGit invokes git with the given arguments, returning a wrapped error that
+// includes combined stdout+stderr on failure.
+func runGit(ctx context.Context, args ...string) error {
+	// #nosec G204 -- args are internal, not user-supplied; only "git" is invoked.
+	out, err := exec.CommandContext(ctx, "git", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git %v: %s: %w", args, out, err)
 	}

--- a/dotool/infect.go
+++ b/dotool/infect.go
@@ -12,7 +12,7 @@ import (
 func buildStructure(homeDir string) error {
 	for _, dir := range []string{"Projects", "bin", "tmp"} {
 		dirPath := filepath.Join(homeDir, dir)
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
+		if err := os.MkdirAll(dirPath, 0750); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 		}
 	}
@@ -81,7 +81,7 @@ func linkSpecificFiles(homeDir string) error {
 		}
 
 		targetPath := filepath.Join(homeDir, "."+relativePath)
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0750); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", targetPath, err)
 		}
 
@@ -113,7 +113,7 @@ func createSymlink(source, target, homeDir string) error {
 		// A pre-existing symlink has no data to preserve — just drop it.
 		if info.Mode()&os.ModeSymlink == 0 {
 			backupDir := filepath.Join(homeDir, "tmp")
-			if err := os.MkdirAll(backupDir, 0755); err != nil {
+			if err := os.MkdirAll(backupDir, 0750); err != nil {
 				return fmt.Errorf("failed to create backup directory %s: %w", backupDir, err)
 			}
 			backupPath := filepath.Join(backupDir, fmt.Sprintf("%s.%d.backup", filepath.Base(target), time.Now().Unix()))
@@ -159,11 +159,13 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
+	// #nosec G304 -- src is a program-controlled path inside link/ or a temp clone dir.
 	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
+	// #nosec G306,G703 -- preserves srcInfo.Mode() to faithfully mirror the source file; dst is program-controlled.
 	return os.WriteFile(dst, data, srcInfo.Mode())
 }
 

--- a/dotool/infect_test.go
+++ b/dotool/infect_test.go
@@ -10,13 +10,13 @@ func TestLinkDirectory(t *testing.T) {
 	tempDir := t.TempDir()
 
 	sourceDir := filepath.Join(tempDir, "link")
-	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+	if err := os.MkdirAll(sourceDir, 0750); err != nil {
 		t.Fatalf("failed to create source directory: %v", err)
 	}
 
 	testFiles := []string{"file1.txt", "file2.txt", "config.conf"}
 	for _, file := range testFiles {
-		if err := os.WriteFile(filepath.Join(sourceDir, file), []byte("test content for "+file), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(sourceDir, file), []byte("test content for "+file), 0600); err != nil {
 			t.Fatalf("failed to create test file %s: %v", file, err)
 		}
 	}
@@ -57,16 +57,16 @@ func TestLinkSpecificFiles(t *testing.T) {
 	}
 	for filePath, content := range testFiles {
 		fullPath := filepath.Join(tempDir, "specific", filePath)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0750); err != nil {
 			t.Fatalf("failed to create directory for %s: %v", filePath, err)
 		}
-		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(fullPath, []byte(content), 0600); err != nil {
 			t.Fatalf("failed to create test file %s: %v", filePath, err)
 		}
 	}
 
 	homeDir := filepath.Join(tempDir, "home")
-	if err := os.MkdirAll(homeDir, 0755); err != nil {
+	if err := os.MkdirAll(homeDir, 0750); err != nil {
 		t.Fatalf("failed to create home directory: %v", err)
 	}
 
@@ -85,18 +85,18 @@ func TestLinkBinFiles(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)
 
-	if err := os.MkdirAll(filepath.Join(tempDir, "bin"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tempDir, "bin"), 0750); err != nil {
 		t.Fatalf("failed to create bin directory: %v", err)
 	}
 	testFiles := []string{"script1.sh", "script2.py", "tool"}
 	for _, file := range testFiles {
-		if err := os.WriteFile(filepath.Join(tempDir, "bin", file), []byte("#!/bin/bash\necho test"), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "bin", file), []byte("#!/bin/bash\necho test"), 0600); err != nil {
 			t.Fatalf("failed to create test file %s: %v", file, err)
 		}
 	}
 
 	homeDir := filepath.Join(tempDir, "home")
-	if err := os.MkdirAll(filepath.Join(homeDir, "bin"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(homeDir, "bin"), 0750); err != nil {
 		t.Fatalf("failed to create home bin directory: %v", err)
 	}
 

--- a/dotool/main.go
+++ b/dotool/main.go
@@ -1,6 +1,9 @@
+// Package main implements dotool, a CLI for managing dotfiles via symlinks
+// and for updating bundled vim plugins and oh-my-zsh.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -17,19 +20,19 @@ var rootCmd = &cobra.Command{
 var infectCmd = &cobra.Command{
 	Use:   "infect",
 	Short: "Install dotfiles and link all configuration files",
-	RunE:  func(cmd *cobra.Command, args []string) error { return runInfect() },
+	RunE:  func(_ *cobra.Command, _ []string) error { return runInfect() },
 }
 
 var vimCmd = &cobra.Command{
 	Use:   "vim",
 	Short: "Update vim plugins and sort spell file",
-	RunE:  func(cmd *cobra.Command, args []string) error { return runVim() },
+	RunE:  func(cmd *cobra.Command, _ []string) error { return runVim(cmd.Context()) },
 }
 
 var omzCmd = &cobra.Command{
 	Use:   "omz",
 	Short: "Update oh-my-zsh to latest version",
-	RunE:  func(cmd *cobra.Command, args []string) error { return updateOhMyZsh() },
+	RunE:  func(cmd *cobra.Command, _ []string) error { return updateOhMyZsh(cmd.Context()) },
 }
 
 func init() {
@@ -56,14 +59,14 @@ func runInfect() error {
 	return nil
 }
 
-func runVim() error {
+func runVim(ctx context.Context) error {
 	log.Println("Running vim command...")
 
-	if err := sortVimSpell(); err != nil {
+	if err := sortVimSpell(ctx); err != nil {
 		return fmt.Errorf("failed to sort vim spell: %w", err)
 	}
 
-	if err := upgradeVimPlugins(); err != nil {
+	if err := upgradeVimPlugins(ctx); err != nil {
 		return fmt.Errorf("failed to upgrade vim plugins: %w", err)
 	}
 

--- a/dotool/main_test.go
+++ b/dotool/main_test.go
@@ -24,7 +24,7 @@ func TestCreateSymlink(t *testing.T) {
 	tempDir := t.TempDir()
 
 	sourceFile := filepath.Join(tempDir, "source.txt")
-	if err := os.WriteFile(sourceFile, []byte("test content"), 0644); err != nil {
+	if err := os.WriteFile(sourceFile, []byte("test content"), 0600); err != nil {
 		t.Fatalf("failed to create source file: %v", err)
 	}
 
@@ -59,7 +59,7 @@ func TestCreateSymlink(t *testing.T) {
 
 	t.Run("over existing regular file — backed up", func(t *testing.T) {
 		target := filepath.Join(tempDir, "regular.txt")
-		if err := os.WriteFile(target, []byte("pre-existing"), 0644); err != nil {
+		if err := os.WriteFile(target, []byte("pre-existing"), 0600); err != nil {
 			t.Fatalf("setup file: %v", err)
 		}
 		before := countBackups()

--- a/dotool/vim_impl.go
+++ b/dotool/vim_impl.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -36,7 +37,7 @@ var vimPlugins = []string{
 	"wakatime/vim-wakatime",
 }
 
-func sortVimSpell() error {
+func sortVimSpell(ctx context.Context) error {
 	log.Println("Sorting vim spell...")
 
 	spellFile := "link/vim/spell/en.utf-8.add"
@@ -48,7 +49,7 @@ func sortVimSpell() error {
 		return fmt.Errorf("failed to sort spell file: %w", err)
 	}
 
-	if err := gitCommitAll("vim spell sort"); err != nil {
+	if err := gitCommitAll(ctx, "vim spell sort"); err != nil {
 		return err
 	}
 
@@ -56,16 +57,16 @@ func sortVimSpell() error {
 	return nil
 }
 
-func upgradeVimPlugins() error {
+func upgradeVimPlugins(ctx context.Context) error {
 	log.Println("Upgrading vim plugins...")
 
 	for _, repo := range vimPlugins {
-		if err := upgradePlugin(repo); err != nil {
+		if err := upgradePlugin(ctx, repo); err != nil {
 			return fmt.Errorf("failed to upgrade plugin %s: %w", repo, err)
 		}
 	}
 
-	if err := gitCommitAll("vim upgrades"); err != nil {
+	if err := gitCommitAll(ctx, "vim upgrades"); err != nil {
 		return err
 	}
 
@@ -73,7 +74,7 @@ func upgradeVimPlugins() error {
 	return nil
 }
 
-func upgradePlugin(repo string) error {
+func upgradePlugin(ctx context.Context, repo string) error {
 	log.Printf("Upgrading plugin: %s\n", repo)
 
 	owner, name, ok := strings.Cut(repo, "/")
@@ -88,7 +89,8 @@ func upgradePlugin(repo string) error {
 	}
 
 	cloneURL := fmt.Sprintf("git@github.com:%s.git", repo)
-	if out, err := exec.Command("git", "clone", cloneURL, pluginDir).CombinedOutput(); err != nil {
+	// #nosec G204 -- repo comes from the program's hardcoded vimPlugins list, not user input.
+	if out, err := exec.CommandContext(ctx, "git", "clone", cloneURL, pluginDir).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to clone plugin %s: %s: %w", repo, string(out), err)
 	}
 
@@ -102,6 +104,7 @@ func upgradePlugin(repo string) error {
 			return err
 		}
 		if d.IsDir() && d.Name() == ".terraform" {
+			// #nosec G122 -- pluginDir is program-controlled, not user-supplied; symlink TOCTOU not a concern for a local dev tool.
 			if err := os.RemoveAll(path); err != nil {
 				return err
 			}
@@ -113,19 +116,20 @@ func upgradePlugin(repo string) error {
 		return fmt.Errorf("failed to scrub .terraform from %s: %w", pluginDir, walkErr)
 	}
 
-	if out, err := exec.Command("git", "add", pluginDir).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to add plugin %s to git: %s: %w", pluginDir, string(out), err)
+	if err := runGit(ctx, "add", pluginDir); err != nil {
+		return fmt.Errorf("failed to add plugin %s to git: %w", pluginDir, err)
 	}
 
 	return nil
 }
 
 func sortSpellFile(filename string) error {
+	// #nosec G304 -- filename is a program-controlled path under link/vim/spell.
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	seen := make(map[string]bool)
 	var lines []string
@@ -150,5 +154,6 @@ func sortSpellFile(filename string) error {
 		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
 	})
 
+	// #nosec G306 -- vim spell file is a user-facing config; 0644 is the standard mode.
 	return os.WriteFile(filename, []byte(strings.Join(lines, "\n")+"\n"), 0644)
 }

--- a/dotool/vim_test.go
+++ b/dotool/vim_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -13,7 +14,7 @@ func TestSortSpellFile(t *testing.T) {
 	spellFile := filepath.Join(tempDir, "en.utf-8.add")
 
 	input := "zebra\nalpha\nBeta\nzebra\nalpha\n\nbeta\n"
-	if err := os.WriteFile(spellFile, []byte(input), 0644); err != nil {
+	if err := os.WriteFile(spellFile, []byte(input), 0600); err != nil {
 		t.Fatalf("failed to create spell file: %v", err)
 	}
 
@@ -21,6 +22,7 @@ func TestSortSpellFile(t *testing.T) {
 		t.Fatalf("sortSpellFile() error = %v", err)
 	}
 
+	// #nosec G304 -- spellFile is a t.TempDir() path in test scope.
 	data, err := os.ReadFile(spellFile)
 	if err != nil {
 		t.Fatalf("failed to read spell file: %v", err)
@@ -35,7 +37,7 @@ func TestSortSpellFile(t *testing.T) {
 
 func TestSortVimSpellMissingFile(t *testing.T) {
 	t.Chdir(t.TempDir())
-	if err := sortVimSpell(); err == nil {
+	if err := sortVimSpell(context.Background()); err == nil {
 		t.Error("sortVimSpell() should return error when spell file doesn't exist")
 	}
 }
@@ -44,7 +46,7 @@ func TestUpgradePluginInvalidFormat(t *testing.T) {
 	cases := []string{"invalid-repo-format", "", "/missing-owner", "missing-name/"}
 	for _, repo := range cases {
 		t.Run(repo, func(t *testing.T) {
-			if err := upgradePlugin(repo); err == nil {
+			if err := upgradePlugin(context.Background(), repo); err == nil {
 				t.Errorf("upgradePlugin(%q) expected error", repo)
 			}
 		})

--- a/dotool/zsh_impl.go
+++ b/dotool/zsh_impl.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -9,17 +10,18 @@ import (
 	"strings"
 )
 
-func updateOhMyZsh() error {
+func updateOhMyZsh(ctx context.Context) error {
 	tmpDir, err := os.MkdirTemp("", "ohmyzsh-update-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	cloneDir := filepath.Join(tmpDir, "ohmyzsh")
 	log.Printf("Cloning oh-my-zsh to %s...\n", cloneDir)
 
-	if out, err := exec.Command("git", "clone", "https://github.com/ohmyzsh/ohmyzsh.git", cloneDir).CombinedOutput(); err != nil {
+	// #nosec G204 -- cloneDir is a program-controlled temp path; clone URL is hardcoded.
+	if out, err := exec.CommandContext(ctx, "git", "clone", "https://github.com/ohmyzsh/ohmyzsh.git", cloneDir).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to clone oh-my-zsh: %s: %w", string(out), err)
 	}
 
@@ -39,7 +41,7 @@ func updateOhMyZsh() error {
 	if err := os.RemoveAll(targetDir); err != nil {
 		return fmt.Errorf("failed to remove existing oh-my-zsh directory: %w", err)
 	}
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
 		return fmt.Errorf("failed to create target directory: %w", err)
 	}
 
@@ -81,14 +83,15 @@ func updateOhMyZsh() error {
 		return fmt.Errorf("failed to strip custom from .gitignore: %w", err)
 	}
 
-	if out, err := exec.Command("git", "add", targetDir).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to add oh-my-zsh to git: %s: %w", string(out), err)
+	if err := runGit(ctx, "add", targetDir); err != nil {
+		return fmt.Errorf("failed to add oh-my-zsh to git: %w", err)
 	}
 
-	return gitCommitAll("chore: oh-my-zsh update")
+	return gitCommitAll(ctx, "chore: oh-my-zsh update")
 }
 
 func stripCustomFromGitignore(path string) error {
+	// #nosec G304 -- path is a program-controlled location inside link/oh-my-zsh.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -107,5 +110,6 @@ func stripCustomFromGitignore(path string) error {
 		out = append(out, line)
 	}
 
+	// #nosec G306,G703 -- .gitignore is a user-facing config at a program-controlled path; 0644 is the standard mode.
 	return os.WriteFile(path, []byte(strings.Join(out, "\n")), 0644)
 }


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the findings in the dotool/ Go package so the lint check passes.

## Changes
Grouped by linter:

- **revive**
  - Added package comment in `main.go` to satisfy `package-comments`.
  - Renamed unused `cmd`/`args` cobra `RunE` params to `_`.
- **noctx**
  - Threaded `context.Context` through `gitCommitAll`, `gitTreeClean`, `runGit`, `sortVimSpell`, `upgradeVimPlugins`, `upgradePlugin`, `runVim`, `updateOhMyZsh`; switched to `exec.CommandContext`. Context comes from `cobra.Command.Context()` at the CLI entry points.
- **errcheck**
  - Explicitly drop errors on deferred `file.Close()` and `os.RemoveAll(tmpDir)`.
- **gosec**
  - G301: directory perms `0755` → `0750` in `infect.go`, `zsh_impl.go`, and tests.
  - G306: test fixture WriteFile perms → `0600`.
  - G304/G306/G703/G204/G122: `//nosec` with one-line rationale for program-controlled paths and hardcoded subprocess args (e.g. clone URL hardcoded, plugin list hardcoded, paths inside `link/`).
- Refactor: replaced two direct `exec.Command("git", "add", ...)` call sites with the existing `runGit` helper (post-context refactor).

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./dotool/` — passes
- `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)