### PR TITLE
fix: exclude vendored link/ trees from yamllint and yq formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
         uses: dcarbone/install-yq-action@v1.3.1
       - name: Format YAML files with yq
         run: |
-          # Format all YAML files in place, excluding vim bundles
-          find . -name "*.yml" -o -name "*.yaml" | grep -v "link/vim/bundle" | while read -r file; do
+          # Format all YAML files in place, excluding vendored trees under link/
+          find . -name "*.yml" -o -name "*.yaml" | grep -v "^./link/" | while read -r file; do
             echo "Formatting $file"
             yq -iP '.' "$file"
           done
@@ -70,7 +70,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'feat: format YAML files with yq'
-          file_pattern: '*.yml *.yaml :!.github/workflows/*'
+          file_pattern: '*.yml *.yaml :!.github/workflows/* :!link/*'
           commit_author: GitHub Actions <actions@github.com>
           commit_user_name: github-actions[bot]
           commit_user_email: github-actions[bot]@users.noreply.github.com

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,4 +1,7 @@
 extends: default
+# Everything under link/ is vendored upstream (oh-my-zsh, vim plugins).
+ignore: |
+  link/
 rules:
   line-length: disable
   document-start: disable


### PR DESCRIPTION
CI's `yaml-lint` job has been failing on every push to main. All 36 yamllint findings are in vendored upstream code (`link/oh-my-zsh/`, `link/vim/bundle/`), which overflows reviewdog's annotation limit — the step exits non-zero with `reviewdog: Too many results (annotations) in diff`.

- `.yamllint.yml`: `ignore: link/`. Nothing under `link/` is ours (our 7 YAML files are at the root and under `.github/`), and these trees get re-vendored on every `task vim` / omz update, so a prefix beats enumerating today's offenders.
- `ci.yml`: the yq format step only excluded `link/vim/bundle`, so the first *successful* run would have `yq -iP`'d every vendored oh-my-zsh and `link/vim/pack` file and pushed a bot commit rewriting them. Excluded `link/` there and in the auto-commit `file_pattern`.

Verified locally with the same yamllint (1.38.0) and the same invocation CI uses: `yamllint .` prints nothing, down from 36 problems. Also simulated the yq step on our own files — no diffs, so the auto-commit stays a no-op.

Note: the PR check runs with `filter_mode: added`, so it will go green regardless; the real confirmation is the post-merge push run.